### PR TITLE
correct the stack path transformation from windows to cygwin style

### DIFF
--- a/scripts/func.sh
+++ b/scripts/func.sh
@@ -76,7 +76,7 @@ fix_path() {
   local return_path
   case $(system_type) in
     CYGWIN )
-      return_path=$(cygpath -u "${1}")
+      return_path=$(cygpath -u "${1}" | tr -d '\r')
       ;;
     * )
       return_path=${1}


### PR DESCRIPTION
So, I figured out that the length for the corrected path was too big. What still puzzles me is that I had to remove two symbols instead of one. I guess, it's a kind of a windows newline character or something. Tried to do it with 'tr' command, but failed. If you have a better suggestion, feel free to reject the PR and improve it otherwise. 
Thanks!